### PR TITLE
Fix bug with masking profile name validation

### DIFF
--- a/satori/resources/resource_masking_profile.go
+++ b/satori/resources/resource_masking_profile.go
@@ -28,7 +28,7 @@ func ResourceMaskingProfile() *schema.Resource {
 				ValidateFunc: func(v interface{}, key string) (warns []string, errs []error) {
 					name := v.(string)
 					var isValid = regexp.MustCompile(`^[a-zA-Z ]+$`).MatchString
-					if isValid(name) {
+					if !isValid(name) {
 						errs = append(errs, fmt.Errorf("%q must contain only alphanumeric characters and spaces but got: %q", key, name))
 					}
 					return


### PR DESCRIPTION
While working to setup our code as compliance repo I noticed during testing that we were getting an error message which was clearly not correct. As we were getting messages that our masking profile names were not valid, even though they very clearly were. 
For example 
`Error: "name" must contain only alphanumeric characters and spaces but got: "phone"`

Dug into the code and noticed this condition should be flipped. 

Also while testing I have noticed that there is no back-end validation on the masking profile names, as I was able to work around this bug by adding a non-alphanumeric character, and it successfully created a masking profile in Satori with the invalid name. 

This change should probably be released as a new version as this will be a breaking for anyone who has found a workaround for this via creating masking profiles without valid names.