### PR TITLE
Fix security policy creation while using EVERYONE criteria

### DIFF
--- a/satori/resources/resource_data_access_common.go
+++ b/satori/resources/resource_data_access_common.go
@@ -84,7 +84,9 @@ func resourceToIdentity(resourceIdentity map[string]interface{}) *api.DataAccess
 	identityName := resourceIdentity["name"].(string)
 	identityGroupId := resourceIdentity["group_id"].(string)
 
-	if len(identityName) > 0 {
+  if (identity.IdentityType == "EVERYONE") {
+    identity.Identity = ""
+  } else if len(identityName) > 0 {
 		identity.Identity = identityName
 	} else if len(identityGroupId) > 0 {
 		identity.Identity = identityGroupId


### PR DESCRIPTION
I have been unable to create security policies which use the "EVERYONE" criteria for a masking rule via the terraform provider. After doing some through digging into things, I noticed the outbound api calls created set the criteria identity = `{identityType: "EVERYONE", identity: "EVERYONE"}` which was giving 400 errors from the API. From testing the API myself, for the EVERYONE criteria to work, you have to have `{identityType: "EVERYONE", identity: ""}`. So this second `identity` field was being set to match the `identityType`. 

I have not tested my solution at all, but I assume this is the change needed to resolve this issue. Opening this PR to bring awareness to this bug. 

Cheers and thank you!