### PR TITLE
SGA-9001 Adding `approvers` field to AccessRequestRule resource

### DIFF
--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -289,7 +289,7 @@ Optional:
 Required:
 
 - **id** (String) The ID of the approver entity
-- **type** (String) Approver type, can be either IdP GROUP or USER
+- **type** (String) Approver type, can be either `GROUP` (IdP Group alone) or `USER`
 
 
 <a id="nestedblock--definition--exclude_location"></a>

--- a/docs/resources/request_access_rule.md
+++ b/docs/resources/request_access_rule.md
@@ -28,6 +28,17 @@ resource "satori_request_access_rule" "request_access1_dataset1" {
   }
   revoke_if_not_used_in_days = 90
   require_approver_note = true //default is false
+
+  // Optional to add approvers on an access-rule.
+  approvers {
+    type = "GROUP"
+    id   = "781246b7-461d-493a-a2d6-86f2e5w01ff2"
+  }
+
+  approvers {
+    type = "USER"
+    id   = "78dc2cb7-461d-493a-a2d6-86e71fv4v5d2"
+  }
 }
 
 resource "satori_request_access_rule" "request_access2_dataset1" {
@@ -44,7 +55,7 @@ resource "satori_request_access_rule" "request_access2_dataset1" {
   revoke_if_not_used_in_days = 90
   //dataset default security policies
   security_policies = [ ]
-  require_approver_note = false //optional, as default is false
+  require_approver_note = false // Optional, as default is false
 }
 
 resource "satori_request_access_rule" "request_access3_dataset1" {
@@ -82,6 +93,7 @@ resource "satori_request_access_rule" "request_access1_dataset_definition1" {
 
 ### Optional
 
+- **approvers** (Block List) Identities of Satori users/IdP groups that will be set as access rule approvers. Once an access rule approver is defined, it is the ONLY entity that can approve the request generated from this access rule (see [below for nested schema](#nestedblock--approvers))
 - **enabled** (Boolean) Enable the rule. Defaults to `true`.
 - **expire_in** (Block List, Max: 1) Rule expiration settings. (see [below for nested schema](#nestedblock--expire_in))
 - **id** (String) The ID of this resource.
@@ -103,6 +115,15 @@ Optional:
 Can not be changed after creation.
 - **name** (String) User/group name for identity types of USER and IDP_GROUP.
 Can not be changed after creation.
+
+
+<a id="nestedblock--approvers"></a>
+### Nested Schema for `approvers`
+
+Required:
+
+- **id** (String) The ID of the approver entity
+- **type** (String) Approver type, can be either `GROUP` (IdP Group alone) or `USER`
 
 
 <a id="nestedblock--expire_in"></a>

--- a/examples/access_rule/request_access_rule.tf
+++ b/examples/access_rule/request_access_rule.tf
@@ -14,6 +14,17 @@ resource "satori_request_access_rule" "request_access1_dataset1" {
   }
   revoke_if_not_used_in_days = 90
   require_approver_note = true //default is false
+
+  // Optional to add approvers on an access-rule.
+  approvers {
+    type = "GROUP"
+    id   = "781246b7-461d-493a-a2d6-86f2e5w01ff2"
+  }
+
+  approvers {
+    type = "USER"
+    id   = "78dc2cb7-461d-493a-a2d6-86e71fv4v5d2"
+  }
 }
 
 resource "satori_request_access_rule" "request_access2_dataset1" {
@@ -30,7 +41,7 @@ resource "satori_request_access_rule" "request_access2_dataset1" {
   revoke_if_not_used_in_days = 90
   //dataset default security policies
   security_policies = [ ]
-  require_approver_note = false //optional, as default is false
+  require_approver_note = false // Optional, as default is false
 }
 
 resource "satori_request_access_rule" "request_access3_dataset1" {

--- a/satori/api/common_definition.go
+++ b/satori/api/common_definition.go
@@ -1,0 +1,6 @@
+package api
+
+type ApproverIdentity struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+}

--- a/satori/api/data_access_request_rule.go
+++ b/satori/api/data_access_request_rule.go
@@ -14,6 +14,7 @@ type DataAccessRequestRule struct {
 	UnusedTimeLimit     DataAccessUnusedTimeLimit                `json:"unusedTimeLimit"`
 	SecurityPolicies    *[]string                                `json:"securityPolicyIds,omitempty"`
 	RequireApproverNote bool                                     `json:"requireApproverNote"`
+	Approvers           []ApproverIdentity                       `json:"approvers"`
 }
 
 func (c *Client) CreateDataAccessRequestRule(parentId string, input *DataAccessRequestRule) (*DataAccessRequestRule, error) {

--- a/satori/api/dataset.go
+++ b/satori/api/dataset.go
@@ -45,11 +45,6 @@ type DataSetOutput struct {
 	DataPolicyId string `json:"dataPolicyId"`
 }
 
-type ApproverIdentity struct {
-	Id   string `json:"id"`
-	Type string `json:"type"`
-}
-
 func (c *Client) CreateDataSet(input *DataSet) (*DataSetOutput, error) {
 	output := DataSetOutput{}
 	return &output, c.postJsonForAccount(DataSetApiPrefix, input, &output)

--- a/satori/resources/resource_common.go
+++ b/satori/resources/resource_common.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/satoricyber/terraform-provider-satori/satori/api"
 	"regexp"
 	"sort"
 	"strings"
@@ -318,4 +319,16 @@ func getRelationalLocationResource() *schema.Resource {
 			},
 		},
 	}
+}
+
+func approversInputToResource(approvers []interface{}) []api.ApproverIdentity {
+	approversOutput := make([]api.ApproverIdentity, len(approvers))
+	for i, approver := range approvers {
+		tmp := approver.(map[string]interface{})
+		var mappedApprover api.ApproverIdentity
+		mappedApprover.Id = tmp["id"].(string)
+		mappedApprover.Type = tmp["type"].(string)
+		approversOutput[i] = mappedApprover
+	}
+	return approversOutput
 }

--- a/satori/resources/resource_dataset_common.go
+++ b/satori/resources/resource_dataset_common.go
@@ -80,7 +80,7 @@ func getDatasetDefinitionSchema() *schema.Schema {
 								Type:             schema.TypeString,
 								ValidateDiagFunc: ValidateApproverType,
 								Required:         true,
-								Description:      "Approver type, can be either IdP GROUP or USER",
+								Description:      "Approver type, can be either `GROUP` (IdP Group alone) or `USER`",
 							},
 							"id": &schema.Schema{
 								Type:        schema.TypeString,
@@ -147,16 +147,7 @@ func resourceToDataset(d *schema.ResourceData) (*api.DataSet, error) {
 	out.Name = d.Get("definition.0.name").(string)
 
 	if v, ok := d.GetOk("definition.0.approvers"); ok {
-		approversDefinition := v.([]interface{})
-		approversOutput := make([]api.ApproverIdentity, len(approversDefinition))
-		for i, approver := range approversDefinition {
-			tmp := approver.(map[string]interface{})
-			var mappedApprover api.ApproverIdentity
-			mappedApprover.Id = tmp["id"].(string)
-			mappedApprover.Type = tmp["type"].(string)
-			approversOutput[i] = mappedApprover
-		}
-		out.Approvers = approversOutput
+		out.Approvers = approversInputToResource(v.([]interface{}))
 	} else {
 		out.Approvers = []api.ApproverIdentity{}
 	}


### PR DESCRIPTION
- Adding `approvers` field to the access-request-rule resource in our terraform provider.
- Refactoring code for more reuse able code.
- Updating docs and fixed old description (was not clear before)