### PR TITLE
SGA-9471 AccessPermission resource identity type validation.

### DIFF
--- a/docs/resources/access_rule.md
+++ b/docs/resources/access_rule.md
@@ -87,7 +87,7 @@ resource "satori_access_rule" "perm1_dataset_definition1" {
 
 Required:
 
-- **type** (String) Identity type, valid types are: USER, IDP_GROUP, GROUP, EVERYONE.
+- **type** (String) Identity type, valid types are: USER, DB_USER, IDP_GROUP, GROUP, DATABRICKS_GROUP, DATABRICKS_SERVICE_PRINCIPAL, SNOWFLAKE_ROLE, EVERYONE.
 Can not be changed after creation.
 
 Optional:

--- a/docs/resources/request_access_rule.md
+++ b/docs/resources/request_access_rule.md
@@ -111,7 +111,7 @@ resource "satori_request_access_rule" "request_access1_dataset_definition1" {
 
 Required:
 
-- **type** (String) Identity type, valid types are: USER, IDP_GROUP, GROUP, EVERYONE.
+- **type** (String) Identity type, valid types are: USER, DB_USER, IDP_GROUP, GROUP, DATABRICKS_GROUP, DATABRICKS_SERVICE_PRINCIPAL, SNOWFLAKE_ROLE, EVERYONE.
 Can not be changed after creation.
 
 Optional:

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -285,7 +285,7 @@ Required:
 
 Required:
 
-- **type** (String) Identity type, valid types are: USER, IDP_GROUP, GROUP, CEL, EVERYONE.
+- **type** (String) Identity type, valid types are: USER, DB_USER, IDP_GROUP, GROUP, DATABRICKS_GROUP, DATABRICKS_SERVICE_PRINCIPAL, SNOWFLAKE_ROLE, CEL, EVERYONE.
 Can not be changed after creation.
 
 Optional:
@@ -350,7 +350,7 @@ Required:
 
 Required:
 
-- **type** (String) Identity type, valid types are: USER, IDP_GROUP, GROUP, CEL, EVERYONE.
+- **type** (String) Identity type, valid types are: USER, DB_USER, IDP_GROUP, GROUP, DATABRICKS_GROUP, DATABRICKS_SERVICE_PRINCIPAL, SNOWFLAKE_ROLE, CEL, EVERYONE.
 Can not be changed after creation.
 
 Optional:

--- a/docs/resources/self_service_access_rule.md
+++ b/docs/resources/self_service_access_rule.md
@@ -91,7 +91,7 @@ resource "satori_self_service_access_rule" "self_service1_dataset_definition1" {
 
 Required:
 
-- **type** (String) Identity type, valid types are: USER, IDP_GROUP, GROUP, EVERYONE.
+- **type** (String) Identity type, valid types are: USER, DB_USER, IDP_GROUP, GROUP, DATABRICKS_GROUP, DATABRICKS_SERVICE_PRINCIPAL, SNOWFLAKE_ROLE, EVERYONE.
 Can not be changed after creation.
 
 Optional:

--- a/satori/resources/resource_data_access_common.go
+++ b/satori/resources/resource_data_access_common.go
@@ -109,7 +109,7 @@ func validIdentityTypeList(isCelSupported bool) string {
 	if isCelSupported {
 		identityTypeList += ", CEL"
 	}
-	identityTypeList += ", EVERYONE.\n"
+	identityTypeList += ", EVERYONE.\nCan not be changed after creation."
 
 	return identityTypeList
 }


### PR DESCRIPTION
- Adding restriction for the identity-type field in terraform access-permission resource
- Fixing a bug that caused terraform to update each time the access permission. (name was not set from the read call)