### PR TITLE
SGA-10785 - Add new attributes for MongoDB SRV

### DIFF
--- a/docs/resources/datastore.md
+++ b/docs/resources/datastore.md
@@ -96,6 +96,8 @@ Required:
 
 Optional:
 
+- **aws_hosted_zone_id** (String) MongoDB AWS Hosted Zone ID, The Hosted AWS DNS Zone created for mapping MongoDB SRV records to Satori.
+- **aws_service_role_arn** (String) MongoDB AWS Service Role ARN, The IAM role ARN assumed by the DAC and used for updating records in the hosted DNS zone.
 - **deployment_type** (String) MongoDB deployment type, for now supports only mongodb+srv and mongodb deployment
 
 

--- a/satori/api/datastore.go
+++ b/satori/api/datastore.go
@@ -34,7 +34,9 @@ type DataStoreOutput struct {
 }
 
 type DataStoreSettings struct {
-	DeploymentType string `json:"deploymentType,omitempty"`
+	DeploymentType   string `json:"deploymentType,omitempty"`
+	AwsHostedZoneId  string `json:"awsHostedZoneId,omitempty"`
+	AwsServerRoleArn string `json:"awsServiceRoleArn,omitempty"`
 }
 
 type UnassociatedQueriesCategory struct {

--- a/satori/resources/resource_data_access_common.go
+++ b/satori/resources/resource_data_access_common.go
@@ -183,13 +183,12 @@ func dataAccessUnusedTimeLimitToResource(unusedTimeLimit *api.DataAccessUnusedTi
 func dataAccessIdentityToResource(in *api.DataAccessIdentity) *map[string]interface{} {
 	out := make(map[string]interface{})
 	out["type"] = in.IdentityType
-	out["name"] = in.Identity
+
 	switch in.IdentityType {
-	case "IDP_GROUP", "USER", "CEL":
-		out["name"] = in.Identity
 	case "GROUP":
 		out["group_id"] = in.Identity
-	default:
+	default: // "IDP_GROUP", "USER", "CEL" and others
+		out["name"] = in.Identity
 	}
 	return &out
 }

--- a/satori/resources/resource_datastore_common.go
+++ b/satori/resources/resource_datastore_common.go
@@ -18,6 +18,8 @@ var (
 	BaselineSecurityPolicy      = "baseline_security_policy"
 	Type                        = "type"
 	DeploymentType              = "deployment_type"
+	AwsHostedZoneId             = "aws_hosted_zone_id"
+	AwsServerRoleArn            = "aws_service_role_arn"
 	UnassociatedQueriesCategory = "unassociated_queries_category"
 	Credentials                 = "credentials"
 	Enabled                     = "enabled"
@@ -210,6 +212,15 @@ func getDataStore(c *api.Client, d *schema.ResourceData) (*api.DataStoreOutput, 
 	if len(sasMap) > 0 { // empty result, skip it.
 		d.Set(SatoriAuthSettings, []map[string]interface{}{sasMap})
 	}
+
+	dsSettingsMap, err := GetSatoriDatastoreSettingsDatastoreOutput(result, err)
+	if err != nil {
+		return nil, err
+	}
+	if len(dsSettingsMap) > 0 { // empty result, skip it.
+		d.Set(DataStoreSettings, []map[string]interface{}{dsSettingsMap})
+	}
+
 	return result, err
 }
 

--- a/satori/resources/resource_datastore_settings.go
+++ b/satori/resources/resource_datastore_settings.go
@@ -18,6 +18,16 @@ func GetDataStoreSettingsDefinition() *schema.Schema {
 					Optional:    true,
 					Description: "MongoDB deployment type, for now supports only mongodb+srv and mongodb deployment",
 				},
+				AwsHostedZoneId: {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "MongoDB AWS Hosted Zone ID, The Hosted AWS DNS Zone created for mapping MongoDB SRV records to Satori.",
+				},
+				AwsServerRoleArn: {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "MongoDB AWS Service Role ARN, The IAM role ARN assumed by the DAC and used for updating records in the hosted DNS zone.",
+				},
 			},
 		},
 	}
@@ -35,4 +45,15 @@ func DataStoreSettingsToResource(in []interface{}) (*api.DataStoreSettings, erro
 		}
 	}
 	return &dataStoreSettings, nil
+}
+
+func GetSatoriDatastoreSettingsDatastoreOutput(result *api.DataStoreOutput, err error) (map[string]interface{}, error) {
+	var inInterface map[string]interface{}
+	inJson, _ := json.Marshal(result.DataStoreSettings)
+	err = json.Unmarshal(inJson, &inInterface)
+	if err != nil {
+		return nil, err
+	}
+	tfMap := biTfApiConverter(inInterface, false)
+	return tfMap, nil
 }


### PR DESCRIPTION
Add 2 new attributes for MongoDB SRV data store settings. Relevant for MongoDB SRV hosted in the custom domain and deployed in AWS.

- `aws_hosted_zone_id` - AWS Hosted Zone ID: The Hosted AWS DNS Zone created for mapping MongoDB SRV records to Satori.
- `aws_service_role_arn` - AWS Service Role ARN: The IAM role ARN assumed by the DAC and used for updating records in the hosted DNS zone.