### PR TITLE
SGA-10092 - add location path to terraform

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -22,75 +22,54 @@ resource "satori_dataset" "dataset1" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
 
     approvers {
-        # Currently can be only IdP groups
-        type = "GROUP"
-        id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
+      # Currently can be only IdP groups
+      type = "GROUP"
+      id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
     }
 
     approvers {
-        type = "USER"
-        id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
+      type = "USER"
+      id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
     }
 
     approvers {
-            type = "USER"
-            id   = data.satori_user.data_steward1.id
-        }
+      type = "USER"
+      id   = data.satori_user.data_steward1.id
+    }
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1"
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-        }
-      }
+      location_parts = ["db2", "schema1"]
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema2"
-          table = "table"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema2.table"
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      location_parts = ["db2", "schema1", "tableX"]
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -100,7 +79,7 @@ resource "satori_dataset" "dataset1" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
 // Example with different location types
@@ -109,58 +88,71 @@ resource "satori_dataset" "dataset2" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema1"
     }
 
     include_location {
+      // MongoDB example
+      datastore     = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_path = "db1.collection1"
+    }
+
+    include_location {
+      // MongoDB example
       datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
-      location {
-        mongo_location {
-          db = "db1"
-          collection = "collection1"
-        }
+      location_parts = ["db1", "collection1"]
+    }
+
+    include_location {
+      // MongoDB example
+      datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_parts_full {
+        name = "db1"
+        type = "DATABASE"
+      }
+      location_parts_full {
+        name = "collection1"
+        type = "COLLECTION"
       }
     }
 
     include_location {
       datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
-      location {
-        s3_location {
-          bucket = "bucket1"
-          object_key = "a/b/c"
-        }
+      // S3 example
+      location_parts = ["bucket1", "a/b/c"] // S3 example
+    }
+
+    include_location {
+      datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
+      // S3 example
+      location_parts_full {
+        name = "bucket1"
+        type = "BUCKET"
+      }
+      location_parts_full {
+        name = "a/b/c"
+        type = "OBJECT"
       }
     }
 
     exclude_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1.schema1.tableX"
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -170,59 +162,61 @@ resource "satori_dataset" "dataset2" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
-// Example with deprecated usage of relational_location field
+// Example with deprecated usage of location field (use location_path, location_parts or location_parts_full instead)
 resource "satori_dataset" "dataset3" {
   definition {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
-
-    include_location {
-      datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
-    }
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db1"
+      location {
+        relational_location {
+          db = "db1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema1"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema2"
-        table = "table"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema2"
+          table  = "table"
+        }
       }
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
       relational_location {
-        db = "db2"
+        db     = "db2"
         schema = "schema1"
-        table = "tableX"
+        table  = "tableX"
       }
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -232,7 +226,7 @@ resource "satori_dataset" "dataset3" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 ```
 

--- a/docs/resources/custom_taxonomy_category.md
+++ b/docs/resources/custom_taxonomy_category.md
@@ -44,11 +44,7 @@ resource "satori_custom_taxonomy_classifier" "cls2" {
     datasets = [satori_dataset.dataset1.id]
     include_location {
       datastore = satori_datastore.datastore0.id
-      location {
-        relational_location {
-          db = "db1"
-        }
-      }
+      location_path = "db1"
     }
   }
 }

--- a/docs/resources/custom_taxonomy_classifier.md
+++ b/docs/resources/custom_taxonomy_classifier.md
@@ -76,8 +76,10 @@ Required:
 
 Optional:
 
-- **location** (Block List, Max: 1) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'relational_location' field. (see [below for nested schema](#nestedblock--scope--include_location--location))
-- **relational_location** (Block List, Max: 1, Deprecated) Location for a relational data store. Conflicts with 'location' field. The 'relational_location' field has been deprecated. Please use the 'location' field instead. (see [below for nested schema](#nestedblock--scope--include_location--relational_location))
+- **location** (Block List, Max: 1, Deprecated) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'location_path', 'location_parts' and 'location_parts_full' fields. The 'location' field has been deprecated. Please use the 'location_path', `location_parts` or `location_parts_full` fields instead. (see [below for nested schema](#nestedblock--scope--include_location--location))
+- **location_parts** (List of String) The part separated location path in the data store. Includes an array of path parts when part types are defined with default definitions. For example ['a', 'b', 'c'] in Snowflake data store will path to table 'a' under schema 'b' under database 'a'. Conflicts with 'location', 'location_path', and 'location_parts_full' fields
+- **location_parts_full** (Block List) The full location path definition in the data store. Includes an array of objects with path name and path type. Can be used when the path type should be defined explicitly and not as defined by default. For example [{name= 'a', type= 'DATABASE'},{name= 'b', type= 'SCHEMA'},{name= 'view.c', type= 'VIEW'}]. Conflicts with 'location', 'location_path', and 'location_parts' fields. (see [below for nested schema](#nestedblock--scope--include_location--location_parts_full))
+- **location_path** (String) The short presentation of the location path in the data store. Includes `.` separated string when part types are defined with default definitions. For example 'a.b.c' in Snowflake data store will path to table 'a' under schema 'b' under database 'a'.  Conflicts with 'location', 'location_parts', and 'location_parts_full' fields.
 
 <a id="nestedblock--scope--include_location--location"></a>
 ### Nested Schema for `scope.include_location.location`
@@ -153,16 +155,12 @@ Optional:
 
 
 
-<a id="nestedblock--scope--include_location--relational_location"></a>
-### Nested Schema for `scope.include_location.relational_location`
+<a id="nestedblock--scope--include_location--location_parts_full"></a>
+### Nested Schema for `scope.include_location.location_parts_full`
 
 Required:
 
-- **db** (String) Database name.
-
-Optional:
-
-- **schema** (String) Schema name.
-- **table** (String) Table name.
+- **name** (String) The name of the location part.
+- **type** (String) The type of the location part. Optional values: TABLE, COLUMN, SEMANTIC_MODEL, REPORT, DASHBOARD, DATABASE, SCHEMA, JSON_PATH, WAREHOUSE, ENDPOINT, TYPE, FIELD, EXTERNAL_LOCATION, CATALOG, BUCKET, OBJECT, COLLECTION, VIEW, etc
 
 

--- a/docs/resources/dataset.md
+++ b/docs/resources/dataset.md
@@ -28,75 +28,54 @@ resource "satori_dataset" "dataset1" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
 
     approvers {
-        # Currently can be only IdP groups
-        type = "GROUP"
-        id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
+      # Currently can be only IdP groups
+      type = "GROUP"
+      id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
     }
 
     approvers {
-        type = "USER"
-        id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
+      type = "USER"
+      id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
     }
 
     approvers {
-            type = "USER"
-            id   = data.satori_user.data_steward1.id
-        }
+      type = "USER"
+      id   = data.satori_user.data_steward1.id
+    }
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1"
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-        }
-      }
+      location_parts = ["db2", "schema1"]
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema2"
-          table = "table"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema2.table"
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      location_parts = ["db2", "schema1", "tableX"]
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -106,7 +85,7 @@ resource "satori_dataset" "dataset1" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
 // Example with different location types
@@ -115,58 +94,71 @@ resource "satori_dataset" "dataset2" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema1"
     }
 
     include_location {
+      // MongoDB example
+      datastore     = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_path = "db1.collection1"
+    }
+
+    include_location {
+      // MongoDB example
       datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
-      location {
-        mongo_location {
-          db = "db1"
-          collection = "collection1"
-        }
+      location_parts = ["db1", "collection1"]
+    }
+
+    include_location {
+      // MongoDB example
+      datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_parts_full {
+        name = "db1"
+        type = "DATABASE"
+      }
+      location_parts_full {
+        name = "collection1"
+        type = "COLLECTION"
       }
     }
 
     include_location {
       datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
-      location {
-        s3_location {
-          bucket = "bucket1"
-          object_key = "a/b/c"
-        }
+      // S3 example
+      location_parts = ["bucket1", "a/b/c"] // S3 example
+    }
+
+    include_location {
+      datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
+      // S3 example
+      location_parts_full {
+        name = "bucket1"
+        type = "BUCKET"
+      }
+      location_parts_full {
+        name = "a/b/c"
+        type = "OBJECT"
       }
     }
 
     exclude_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1.schema1.tableX"
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -176,59 +168,61 @@ resource "satori_dataset" "dataset2" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
-// Example with deprecated usage of relational_location field
+// Example with deprecated usage of location field (use location_path, location_parts or location_parts_full instead)
 resource "satori_dataset" "dataset3" {
   definition {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
-
-    include_location {
-      datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
-    }
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db1"
+      location {
+        relational_location {
+          db = "db1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema1"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema2"
-        table = "table"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema2"
+          table  = "table"
+        }
       }
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
       relational_location {
-        db = "db2"
+        db     = "db2"
         schema = "schema1"
-        table = "tableX"
+        table  = "tableX"
       }
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -238,7 +232,7 @@ resource "satori_dataset" "dataset3" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 ```
 
@@ -301,8 +295,10 @@ Required:
 
 Optional:
 
-- **location** (Block List, Max: 1) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'relational_location' field. (see [below for nested schema](#nestedblock--definition--exclude_location--location))
-- **relational_location** (Block List, Max: 1, Deprecated) Location for a relational data store. Conflicts with 'location' field. The 'relational_location' field has been deprecated. Please use the 'location' field instead. (see [below for nested schema](#nestedblock--definition--exclude_location--relational_location))
+- **location** (Block List, Max: 1, Deprecated) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'location_path', 'location_parts' and 'location_parts_full' fields. The 'location' field has been deprecated. Please use the 'location_path', `location_parts` or `location_parts_full` fields instead. (see [below for nested schema](#nestedblock--definition--exclude_location--location))
+- **location_parts** (List of String) The part separated location path in the data store. Includes an array of path parts when part types are defined with default definitions. For example ['a', 'b', 'c'] in Snowflake data store will path to table 'a' under schema 'b' under database 'a'. Conflicts with 'location', 'location_path', and 'location_parts_full' fields
+- **location_parts_full** (Block List) The full location path definition in the data store. Includes an array of objects with path name and path type. Can be used when the path type should be defined explicitly and not as defined by default. For example [{name= 'a', type= 'DATABASE'},{name= 'b', type= 'SCHEMA'},{name= 'view.c', type= 'VIEW'}]. Conflicts with 'location', 'location_path', and 'location_parts' fields. (see [below for nested schema](#nestedblock--definition--exclude_location--location_parts_full))
+- **location_path** (String) The short presentation of the location path in the data store. Includes `.` separated string when part types are defined with default definitions. For example 'a.b.c' in Snowflake data store will path to table 'a' under schema 'b' under database 'a'.  Conflicts with 'location', 'location_parts', and 'location_parts_full' fields.
 
 <a id="nestedblock--definition--exclude_location--location"></a>
 ### Nested Schema for `definition.exclude_location.location`
@@ -378,17 +374,13 @@ Optional:
 
 
 
-<a id="nestedblock--definition--exclude_location--relational_location"></a>
-### Nested Schema for `definition.exclude_location.relational_location`
+<a id="nestedblock--definition--exclude_location--location_parts_full"></a>
+### Nested Schema for `definition.exclude_location.location_parts_full`
 
 Required:
 
-- **db** (String) Database name.
-
-Optional:
-
-- **schema** (String) Schema name.
-- **table** (String) Table name.
+- **name** (String) The name of the location part.
+- **type** (String) The type of the location part. Optional values: TABLE, COLUMN, SEMANTIC_MODEL, REPORT, DASHBOARD, DATABASE, SCHEMA, JSON_PATH, WAREHOUSE, ENDPOINT, TYPE, FIELD, EXTERNAL_LOCATION, CATALOG, BUCKET, OBJECT, COLLECTION, VIEW, etc
 
 
 
@@ -401,8 +393,10 @@ Required:
 
 Optional:
 
-- **location** (Block List, Max: 1) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'relational_location' field. (see [below for nested schema](#nestedblock--definition--include_location--location))
-- **relational_location** (Block List, Max: 1, Deprecated) Location for a relational data store. Conflicts with 'location' field. The 'relational_location' field has been deprecated. Please use the 'location' field instead. (see [below for nested schema](#nestedblock--definition--include_location--relational_location))
+- **location** (Block List, Max: 1, Deprecated) Location for a data store. Can include only one location type field from the above: relational_location, mysql_location, athena_location, mongo_location and s3_location . Conflicts with 'location_path', 'location_parts' and 'location_parts_full' fields. The 'location' field has been deprecated. Please use the 'location_path', `location_parts` or `location_parts_full` fields instead. (see [below for nested schema](#nestedblock--definition--include_location--location))
+- **location_parts** (List of String) The part separated location path in the data store. Includes an array of path parts when part types are defined with default definitions. For example ['a', 'b', 'c'] in Snowflake data store will path to table 'a' under schema 'b' under database 'a'. Conflicts with 'location', 'location_path', and 'location_parts_full' fields
+- **location_parts_full** (Block List) The full location path definition in the data store. Includes an array of objects with path name and path type. Can be used when the path type should be defined explicitly and not as defined by default. For example [{name= 'a', type= 'DATABASE'},{name= 'b', type= 'SCHEMA'},{name= 'view.c', type= 'VIEW'}]. Conflicts with 'location', 'location_path', and 'location_parts' fields. (see [below for nested schema](#nestedblock--definition--include_location--location_parts_full))
+- **location_path** (String) The short presentation of the location path in the data store. Includes `.` separated string when part types are defined with default definitions. For example 'a.b.c' in Snowflake data store will path to table 'a' under schema 'b' under database 'a'.  Conflicts with 'location', 'location_parts', and 'location_parts_full' fields.
 
 <a id="nestedblock--definition--include_location--location"></a>
 ### Nested Schema for `definition.include_location.location`
@@ -478,17 +472,13 @@ Optional:
 
 
 
-<a id="nestedblock--definition--include_location--relational_location"></a>
-### Nested Schema for `definition.include_location.relational_location`
+<a id="nestedblock--definition--include_location--location_parts_full"></a>
+### Nested Schema for `definition.include_location.location_parts_full`
 
 Required:
 
-- **db** (String) Database name.
-
-Optional:
-
-- **schema** (String) Schema name.
-- **table** (String) Table name.
+- **name** (String) The name of the location part.
+- **type** (String) The type of the location part. Optional values: TABLE, COLUMN, SEMANTIC_MODEL, REPORT, DASHBOARD, DATABASE, SCHEMA, JSON_PATH, WAREHOUSE, ENDPOINT, TYPE, FIELD, EXTERNAL_LOCATION, CATALOG, BUCKET, OBJECT, COLLECTION, VIEW, etc
 
 
 

--- a/docs/resources/datastore.md
+++ b/docs/resources/datastore.md
@@ -184,6 +184,10 @@ Required:
 
 ## Example Usage
 
+### Example Usage
+
+### Snowflake Example
+
 ```terraform
 locals {
   dataaccess_controller_id = "<assigned dataaccess_controller_id>"
@@ -297,13 +301,16 @@ output "datastore_created_id" {
   value = satori_datastore.datastore0.id
 }
 ```
+
+### BigQuery Example
+
 ```terraform
 locals {
   dataaccess_controller_id = "<assigned dataaccess_controller_id>"
 }
 
 resource "satori_datastore" "datastore0" {
-  name = "exampleDatastore"
+  name = "exampleDatastoreBigQuery"
 
   dataaccess_controller_id = local.dataaccess_controller_id
   # data source specific connection settings
@@ -365,6 +372,9 @@ output "datastore_created_id" {
   value = satori_datastore.datastore0.id
 }
 ```
+
+### PostgreSQL Example
+
 ```terraform
 locals {
   dataaccess_controller_id = "<assigned dataaccess_controller_id>"
@@ -440,6 +450,9 @@ output "datastore_created_id" {
   value = satori_datastore.datastore0.id
 }
 ```
+
+### Databricks Example
+
 ```terraform
 locals {
   dataaccess_controller_id = "<assigned dataaccess_controller_id>"

--- a/docs/resources/security_policy.md
+++ b/docs/resources/security_policy.md
@@ -99,13 +99,7 @@ resource "satori_security_policy" "security_policy" {
                             name: '33'
                           filterName: Filter 1
                         EOT
-          location {
-            relational_location {
-              db     = "db2"
-              schema = "schema2"
-              table  = "table"
-            }
-          }
+          location_path = "db2.schema2.table"
         }
       }
       rule {
@@ -146,11 +140,7 @@ and:
         path: $.a['b']
       filterName: Filter 1
   EOT
-          location_prefix { // usage of the deprecated field 'location_prefix'
-            db     = "db2"
-            schema = "schema2"
-            table  = "table1"
-          }
+          location_parts = ["db2", "schema2", "table1"]
         }
       }
       mapping {
@@ -394,8 +384,10 @@ Required:
 Optional:
 
 - **advanced** (Boolean) Describes if logic yaml contains complex configuration. Defaults to `true`.
-- **location** (Block List) Location to be included in the rule. (see [below for nested schema](#nestedblock--profile--row_level_security--rule--id--location))
-- **location_prefix** (Block List, Deprecated) Location to to be included in the rule. The 'location_prefix' field has been deprecated. Please use the 'location' field instead. (see [below for nested schema](#nestedblock--profile--row_level_security--rule--id--location_prefix))
+- **location** (Block List, Deprecated) Location to be included in the rule. The 'location' field has been deprecated. Please use the 'location_path', `location_parts` or `location_parts_full` fields instead. (see [below for nested schema](#nestedblock--profile--row_level_security--rule--id--location))
+- **location_parts** (List of String) The part separated location path in the data store. Includes an array of path parts when part types are defined with default definitions. For example ['a', 'b', 'c'] in Snowflake data store will path to table 'a' under schema 'b' under database 'a'. Conflicts with 'location', 'location_path', and 'location_parts_full' fields
+- **location_parts_full** (Block List) The full location path definition in the data store. Includes an array of objects with path name and path type. Can be used when the path type should be defined explicitly and not as defined by default. For example [{name= 'a', type= 'DATABASE'},{name= 'b', type= 'SCHEMA'},{name= 'view.c', type= 'VIEW'}]. Conflicts with 'location', 'location_path', and 'location_parts' fields. (see [below for nested schema](#nestedblock--profile--row_level_security--rule--id--location_parts_full))
+- **location_path** (String) The short presentation of the location path in the data store. Includes `.` separated string when part types are defined with default definitions. For example 'a.b.c' in Snowflake data store will path to table 'a' under schema 'b' under database 'a'.  Conflicts with 'location', 'location_parts', and 'location_parts_full' fields.
 
 <a id="nestedblock--profile--row_level_security--rule--id--location"></a>
 ### Nested Schema for `profile.row_level_security.rule.id.location`
@@ -471,14 +463,10 @@ Optional:
 
 
 
-<a id="nestedblock--profile--row_level_security--rule--id--location_prefix"></a>
-### Nested Schema for `profile.row_level_security.rule.id.location_prefix`
+<a id="nestedblock--profile--row_level_security--rule--id--location_parts_full"></a>
+### Nested Schema for `profile.row_level_security.rule.id.location_parts_full`
 
 Required:
 
-- **db** (String) Database name.
-
-Optional:
-
-- **schema** (String) Schema name.
-- **table** (String) Table name.
+- **name** (String) The name of the location part.
+- **type** (String) The type of the location part. Optional values: TABLE, COLUMN, SEMANTIC_MODEL, REPORT, DASHBOARD, DATABASE, SCHEMA, JSON_PATH, WAREHOUSE, ENDPOINT, TYPE, FIELD, EXTERNAL_LOCATION, CATALOG, BUCKET, OBJECT, COLLECTION, VIEW, etc

--- a/examples/dataset/dataset.tf
+++ b/examples/dataset/dataset.tf
@@ -8,75 +8,54 @@ resource "satori_dataset" "dataset1" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
 
     approvers {
-        # Currently can be only IdP groups
-        type = "GROUP"
-        id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
+      # Currently can be only IdP groups
+      type = "GROUP"
+      id   = "788680b7-461d-493a-a3d6-86e71fd01ff2"
     }
 
     approvers {
-        type = "USER"
-        id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
+      type = "USER"
+      id   = "3d174db4-4526-4469-2fda-46d0dd2a7f7d"
     }
 
     approvers {
-            type = "USER"
-            id   = data.satori_user.data_steward1.id
-        }
+      type = "USER"
+      id   = data.satori_user.data_steward1.id
+    }
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1"
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-        }
-      }
+      location_parts = ["db2", "schema1"]
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema2"
-          table = "table"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema2.table"
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db2"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      location_parts = ["db2", "schema1", "tableX"]
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -86,7 +65,7 @@ resource "satori_dataset" "dataset1" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
 // Example with different location types
@@ -95,58 +74,71 @@ resource "satori_dataset" "dataset2" {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
     }
 
     include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db2.schema1"
     }
 
     include_location {
+      // MongoDB example
+      datastore     = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_path = "db1.collection1"
+    }
+
+    include_location {
+      // MongoDB example
       datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
-      location {
-        mongo_location {
-          db = "db1"
-          collection = "collection1"
-        }
+      location_parts = ["db1", "collection1"]
+    }
+
+    include_location {
+      // MongoDB example
+      datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_parts_full {
+        name = "db1"
+        type = "DATABASE"
+      }
+      location_parts_full {
+        name = "collection1"
+        type = "COLLECTION"
       }
     }
 
     include_location {
       datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
-      location {
-        s3_location {
-          bucket = "bucket1"
-          object_key = "a/b/c"
-        }
+      // S3 example
+      location_parts = ["bucket1", "a/b/c"] // S3 example
+    }
+
+    include_location {
+      datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
+      // S3 example
+      location_parts_full {
+        name = "bucket1"
+        type = "BUCKET"
+      }
+      location_parts_full {
+        name = "a/b/c"
+        type = "OBJECT"
       }
     }
 
     exclude_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      location {
-        relational_location {
-          db = "db1"
-          schema = "schema1"
-          table = "tableX"
-        }
-      }
+      datastore     = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_path = "db1.schema1.tableX"
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -156,59 +148,61 @@ resource "satori_dataset" "dataset2" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }
 
-// Example with deprecated usage of relational_location field
+// Example with deprecated usage of location field (use location_path, location_parts or location_parts_full instead)
 resource "satori_dataset" "dataset3" {
   definition {
     name = "satori_dataset terraform test"
     description = "from satori terraform provider"
     #the service account must also be an owner to be able to modify settings beyond definition
-    owners = [ "522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
-
-    include_location {
-      datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
-    }
+    owners = ["522fb8ab-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db1"
+      location {
+        relational_location {
+          db = "db1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema1"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema1"
+        }
       }
     }
 
     include_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema2"
-        table = "table"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema2"
+          table  = "table"
+        }
       }
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
       relational_location {
-        db = "db2"
+        db     = "db2"
         schema = "schema1"
-        table = "tableX"
+        table  = "tableX"
       }
     }
   }
 
   access_control_settings {
     enable_access_control = false
-    enable_user_requests = false
-    enable_self_service = false
+    enable_user_requests  = false
+    enable_self_service   = false
   }
 
   custom_policy {
@@ -218,5 +212,5 @@ resource "satori_dataset" "dataset3" {
     tags_yaml = file("${path.module}/tags.yaml")
   }
 
-  security_policies = [ "56412aff-6ecf-4eff-9b96-2e0f6ec36c42" ]
+  security_policies = ["56412aff-6ecf-4eff-9b96-2e0f6ec36c42"]
 }

--- a/examples/dataset/dataset_definition.tf
+++ b/examples/dataset/dataset_definition.tf
@@ -5,9 +5,37 @@ data "satori_user" "data_steward1" {
 
 resource "satori_dataset_definition" "dataset_definition1" {
   definition {
-    name = "satori_dataset_definition terraform test"
+    name        = "satori_dataset_definition terraform test"
     description = "from satori terraform provider"
-    owners = [ "12345678-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
+    owners = ["12345678-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
+
+    include_location {
+      datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
+    }
+
+    include_location {
+      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location_parts = ["db1", "schema1"]
+    }
+
+    include_location {
+      datastore     = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      location_path = "db1.collection1"
+    }
+
+    include_location {
+      datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
+      location_parts = ["bucket1", "a/b/c"]
+    }
+  }
+}
+
+// Example with deprecated usage of location field (use location_path, location_parts or location_parts_full instead)
+resource "satori_dataset_definition" "dataset_definition2" {
+  definition {
+    name        = "satori_dataset_definition terraform test"
+    description = "from satori terraform provider"
+    owners = ["12345678-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id]
 
     include_location {
       datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
@@ -18,74 +46,40 @@ resource "satori_dataset_definition" "dataset_definition1" {
       location {
         relational_location {
           db = "db1"
+        }
+      }
+
+    }
+
+    include_location {
+      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
+      location {
+        relational_location {
+          db     = "db2"
           schema = "schema1"
         }
       }
     }
 
     include_location {
-      datastore = "3go33ff5-95cf-474f-a1d6-d5084810dd5k"
+      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
       location {
-        mongo_location {
-          db = "db1"
-          collection = "collection1"
+        relational_location {
+          db     = "db2"
+          schema = "schema2"
+          table  = "table"
         }
-      }
-    }
-
-    include_location {
-      datastore = "8kl43ff5-95cf-474f-a1d6-d508481049lw"
-      location {
-        s3_location {
-          bucket = "bucket1"
-          object_key = "a/b/c"
-        }
-      }
-    }
-  }
-}
-
-// Example with deprecated usage of relational_location field
-resource "satori_dataset_definition" "dataset_definition2" {
-  definition {
-    name = "satori_dataset_definition terraform test"
-    description = "from satori terraform provider"
-    owners = [ "12345678-8d7b-4498-b39d-6911e2839253", data.satori_user.data_steward1.id ]
-
-    include_location {
-      datastore = "12345678-95cf-474f-a1d6-d5084810dd95"
-    }
-
-    include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db1"
-      }
-    }
-
-    include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema1"
-      }
-    }
-
-    include_location {
-      datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema2"
-        table = "table"
       }
     }
 
     exclude_location {
       datastore = "80f33ff5-95cf-474f-a1d6-d5084810dd95"
-      relational_location {
-        db = "db2"
-        schema = "schema1"
-        table = "tableX"
+      location {
+        relational_location {
+          db     = "db2"
+          schema = "schema1"
+          table  = "tableX"
+        }
       }
     }
   }

--- a/examples/datastore/datastore-BigQuery.tf
+++ b/examples/datastore/datastore-BigQuery.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "satori_datastore" "datastore0" {
-  name = "exampleDatastore"
+  name = "exampleDatastoreBigQuery"
 
   dataaccess_controller_id = local.dataaccess_controller_id
   # data source specific connection settings

--- a/examples/personal_user_schemas/user_schemas.tf
+++ b/examples/personal_user_schemas/user_schemas.tf
@@ -31,12 +31,7 @@ resource "satori_dataset" "dataset_for_personal_schema" {
 
     include_location {
       datastore = local.datastore_id
-      location {
-        relational_location {
-          db = local.database_name
-          schema = each.value.schema
-        }
-      }
+      location_parts = [local.database_name, each.value.schema] // S3 example
     }      
   }
 

--- a/examples/security_policy/security_policy.tf
+++ b/examples/security_policy/security_policy.tf
@@ -82,13 +82,7 @@ resource "satori_security_policy" "security_policy" {
                             name: '33'
                           filterName: Filter 1
                         EOT
-          location {
-            relational_location {
-              db     = "db2"
-              schema = "schema2"
-              table  = "table"
-            }
-          }
+          location_path = "db2.schema2.table"
         }
       }
       rule {
@@ -129,11 +123,7 @@ and:
         path: $.a['b']
       filterName: Filter 1
   EOT
-          location_prefix { // usage of the deprecated field 'location_prefix'
-            db     = "db2"
-            schema = "schema2"
-            table  = "table1"
-          }
+          location_parts = ["db2", "schema2", "table1"]
         }
       }
       mapping {

--- a/examples/taxonomy/taxonomy.tf
+++ b/examples/taxonomy/taxonomy.tf
@@ -30,11 +30,7 @@ resource "satori_custom_taxonomy_classifier" "cls2" {
     datasets = [satori_dataset.dataset1.id]
     include_location {
       datastore = satori_datastore.datastore0.id
-      location {
-        relational_location {
-          db = "db1"
-        }
-      }
+      location_path = "db1"
     }
   }
 }

--- a/satori/api/dataset.go
+++ b/satori/api/dataset.go
@@ -3,8 +3,9 @@ package api
 const DataSetApiPrefix = "/api/v1/dataset"
 
 type DataSetLocation struct {
-	DataStoreId string                  `json:"dataStoreId"`
-	Location    *DataSetGenericLocation `json:"location,omitempty"`
+	DataStoreId  string                  `json:"dataStoreId"`
+	Location     *DataSetGenericLocation `json:"location,omitempty"`
+	LocationPath []LocationPath          `json:"locationPath,omitempty"`
 }
 
 // DataSetGenericLocation
@@ -24,6 +25,11 @@ type DataSetGenericLocation struct {
 	Collection *string `json:"collection,omitempty"`
 	Bucket     *string `json:"bucket,omitempty"`
 	ObjectKey  *string `json:"objectKey,omitempty"`
+}
+
+type LocationPath struct {
+	Name string `json:"name"`
+	Type string `json:"type,omitempty"`
 }
 
 type DataSet struct {

--- a/satori/api/security_policy.go
+++ b/satori/api/security_policy.go
@@ -53,7 +53,8 @@ type MaskingRule struct {
 // ///////////////////
 type RowLevelSecurityRuleFilter struct {
 	DataStoreId    string                  `json:"dataStoreId"`
-	LocationPrefix *DataSetGenericLocation `json:"locationPrefix"`
+	LocationPrefix *DataSetGenericLocation `json:"locationPrefix,omitempty"`
+	LocationPath   []LocationPath          `json:"locationPath,omitempty"`
 	LogicYaml      string                  `json:"logicYaml"`
 	Advanced       bool                    `json:"advanced"`
 }

--- a/satori/resources/resource_taxonomy_classifier.go
+++ b/satori/resources/resource_taxonomy_classifier.go
@@ -225,8 +225,9 @@ func resourceClassifierCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	result, err := c.CreateTaxonomyClassifier(input)
+
 	if err != nil {
-		diag.FromErr(err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(result.Id)
@@ -303,7 +304,7 @@ func resourceClassifierRead(ctx context.Context, d *schema.ResourceData, m inter
 		scope["datasets"] = result.Scope.DatasetIds
 	}
 	if len(result.Scope.IncludeLocations) > 0 {
-		scope["include_location"] = locationsToResource(&result.Scope.IncludeLocations, d, "scope.0.include_location", RelationalLocation)
+		scope["include_location"] = locationsToResource(&result.Scope.IncludeLocations, d, "scope.0.include_location", Location)
 	}
 	if err := setMapProp(&scope, "scope", d); err != nil {
 		return diag.FromErr(err)

--- a/satori/resources/utils.go
+++ b/satori/resources/utils.go
@@ -2,6 +2,10 @@ package resources
 
 import (
 	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"strings"
 )
 
 // This function makes a consistent string that represents json.
@@ -17,4 +21,38 @@ func normalizeDataJSON(val interface{}) string {
 	ret, _ := json.Marshal(dataMap)
 
 	return string(ret)
+}
+
+func StringIsNotWhiteSpaceInArray(v interface{}, p cty.Path) diag.Diagnostics {
+	value, ok := v.(string)
+	var diags diag.Diagnostics
+
+	if !ok {
+		diagValue := diag.Diagnostic{
+			Severity:      diag.Error,
+			Summary:       "Wrong value type",
+			Detail:        fmt.Sprintf("expected type of %s to be string", p),
+			AttributePath: p,
+		}
+		diags = append(diags, diagValue)
+	} else {
+		if strings.TrimSpace(value) == "" {
+			errorMessage := fmt.Sprintf("value is expected to not be an empty string or whitespace.")
+
+			attr, okIndexStepCasting := p[len(p)-1].(cty.IndexStep)
+			if okIndexStepCasting && attr.Key.AsBigFloat() != nil {
+				index := attr.Key.AsBigFloat().String()
+				errorMessage = fmt.Sprintf("value at index %s is expected to not be an empty string or whitespace.", index)
+			}
+
+			diagValue := diag.Diagnostic{
+				Severity:      diag.Error,
+				Summary:       "Empty string is not allowed",
+				Detail:        errorMessage,
+				AttributePath: p,
+			}
+			diags = append(diags, diagValue)
+		}
+	}
+	return diags
 }

--- a/templates/resources/datastore.md.tmpl
+++ b/templates/resources/datastore.md.tmpl
@@ -14,9 +14,22 @@ The **satori_datastore** resource allows lifecycle management for the datastores
 
 ## Example Usage
 
+### Example Usage
+
+### Snowflake Example
+
 {{tffile "examples/datastore/datastore.tf"}}
+
+### BigQuery Example
+
 {{tffile "examples/datastore/datastore-BigQuery.tf"}}
+
+### PostgreSQL Example
+
 {{tffile "examples/datastore/datastore-PostgreSql.tf"}}
+
+### Databricks Example
+
 {{tffile "examples/datastore/datastore-Databricks.tf"}}
 
 ~> **Note: The datastore resource is stateful:** The datastore resource is stateful, deletion or terraform resource name change should be avoided.


### PR DESCRIPTION
Release notes:
1. The `relational_location` fields in 3 following schema were removed
    1. satori_dataset . definition .  include_location / exclude_location
    2. security_policy . row_level_security . profile . row_level_security . rule . id . filter
    3. satori_custom_taxonomy_classifier . scope . include_location
    4. Note: if this schema still in use, you should change it to `location` schema then upgrade and then use new format.
2. The `location` field in following nested schemas has been deprecated:
    1. satori_dataset . definition .  include_location / exclude_location
    2. security_policy . row_level_security . profile . row_level_security . rule . id . filter
3. New and simplified fields for location path has been introduced, please use one of the following:
    1. location_path
    2. location_parts
    3. location_parts_full