### PR TITLE
SGA-12135 - eliminate the harder requirement of using lifecycle.ignore_changes

### DIFF
--- a/satori/resources/resource_datastore_satori_auth_settings.go
+++ b/satori/resources/resource_datastore_satori_auth_settings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/satoricyber/terraform-provider-satori/satori/api"
+	"log"
 )
 
 func GetSatoriAuthSettingsDefinitions() *schema.Schema {
@@ -51,7 +52,7 @@ func GetSatoriAuthSettingsDefinitions() *schema.Schema {
 		},
 	}
 }
-func GetSatoriAuthSettingsDatastoreOutput(result *api.DataStoreOutput, err error) (map[string]interface{}, error) {
+func GetSatoriAuthSettingsDatastoreOutput(d *schema.ResourceData, result *api.DataStoreOutput, err error) (map[string]interface{}, error) {
 	var inInterface map[string]interface{}
 	inJson, _ := json.Marshal(result.SatoriAuthSettings)
 	err = json.Unmarshal(inJson, &inInterface)
@@ -59,10 +60,30 @@ func GetSatoriAuthSettingsDatastoreOutput(result *api.DataStoreOutput, err error
 		return nil, err
 	}
 	tfMap := biTfApiConverter(inInterface, false)
+	if len(tfMap) == 0 { // empty result, skip it.
+		return tfMap, nil
+	}
+
+	// If arrived here, it means that there is a configuration...
+	// Check if the password has changed.
+	// If the password has not changed, we need to set the password to the old/new value to state (simulating the backend response)
+	// This is done for terraform update bypass.
+	// The implementation is based on the fact that the password is stored in the terraform state.
+	passwordResourcePath := "satori_auth_settings.0.credentials.0.password"
+	if !d.HasChange(passwordResourcePath) { // no change
+		log.Printf("The password hasn't change from state, overriding it with the old value")
+		oldV, _ := d.GetChange(passwordResourcePath)
+		credentialsMap := tfMap[Credentials].([]map[string]interface{})
+		if len(credentialsMap) > 0 { // found credentials object (has to be defined)
+			credentials := credentialsMap[0]      // it can be only 1 credentials object
+			credentials[Password] = oldV.(string) // override the password with the old value
+		}
+	}
+
 	return tfMap, nil
 }
 
-func SatoriAuthSettingsToResource(in []interface{}) (*api.SatoriAuthSettings, error) {
+func SatoriAuthSettingsToResource(d *schema.ResourceData, in []interface{}) (*api.SatoriAuthSettings, error) {
 	var satoriAuthSettings api.SatoriAuthSettings
 	mapSatoriAuthSettings := extractMapFromInterface(in)
 	if mapSatoriAuthSettings != nil {


### PR DESCRIPTION
Eliminates the harder requirement of using `lifecycle.ignore_changes` for `satori_auth_settings.0.credentials.0.password` only.

Since the password is not returned from the backend, the Terraform state has no idea if it was changed or not.

Therefore, the lifecycle.ignore_changes was introduced, which ignores the change of this property.

However, it can be challenging for automation, as any password update requires 2 changes in tf file, first, without lifecycle.ignore_changes and the second with.

The fix introduces the manipulation of Terraform state, which eliminates the harder requirement of using lifecycle.ignore_changes